### PR TITLE
Make InfoStream thread-safe for output

### DIFF
--- a/perpVects/InfoStream.cpp
+++ b/perpVects/InfoStream.cpp
@@ -1,0 +1,54 @@
+#include "InfoStream.h"
+
+#include <mutex>
+
+namespace {
+  class NullBuffer : public std::streambuf {
+  public:
+    int overflow(int c) override { return c; }
+  };
+
+  class InfoStreamBackend : public std::ostream {
+  public:
+    InfoStreamBackend() : std::ostream(), _null() { hide(); }
+    ~InfoStreamBackend() { hide(); }
+    void show() { init(std::cout.rdbuf()); }
+    void hide() { init(&_null); }
+
+  private:
+    NullBuffer _null;
+  };
+
+  static InfoStreamBackend infoStreamBackendSingleton;
+  std::mutex infoStreamMutex;
+}
+
+InfoStream::InfoStream()
+  : std::ostream()
+  , _threadbuf()
+{
+  init(_threadbuf.rdbuf());
+}
+
+InfoStream::~InfoStream() {
+  flushout();
+}
+
+void InfoStream::show() {
+  std::lock_guard<std::mutex> locker(infoStreamMutex);
+  infoStreamBackendSingleton.show();
+}
+
+void InfoStream::hide() {
+  std::lock_guard<std::mutex> locker(infoStreamMutex);
+  infoStreamBackendSingleton.show();
+}
+
+void InfoStream::flushout() {
+  {
+    std::lock_guard<std::mutex> locker(infoStreamMutex);
+    infoStreamBackendSingleton << _threadbuf.str();
+  }
+  _threadbuf.str("");
+}
+

--- a/perpVects/InfoStream.h
+++ b/perpVects/InfoStream.h
@@ -1,0 +1,25 @@
+#ifndef INFO_STREAM_H
+#define INFO_STREAM_H
+
+#include <sstream>
+#include <iostream>
+
+class InfoStream : public std::ostream {
+public:
+  InfoStream();
+  ~InfoStream();
+
+  // enable move
+  InfoStream(InfoStream &&other) = default;
+  InfoStream& operator=(InfoStream &&other) = default;
+
+  void show();
+  void hide();
+  void flushout();
+
+private:
+  std::ostringstream _threadbuf;
+};
+
+#endif // INFO_STREAM_H
+

--- a/perpVects/QFPHelpers.cpp
+++ b/perpVects/QFPHelpers.cpp
@@ -22,7 +22,9 @@ printOnce(std::string s, void* addr){
   }
 }
 
-InfoStream info_stream;
+thread_local InfoStream info_stream;
+std::mutex ostreamMutex;
+
 std::ostream& operator<<(std::ostream& os, const unsigned __int128 i) {
   uint64_t hi = i >> 64;
   uint64_t lo = (uint64_t)i;
@@ -36,8 +38,6 @@ std::ostream& operator<<(std::ostream& os, const unsigned __int128 &i){
   os << hi << lo;
   return os;
 }
-
-std::mutex ostreamMutex;
 
 std::string
 getSortName(sort_t val){

--- a/perpVects/QFPHelpers.h
+++ b/perpVects/QFPHelpers.h
@@ -5,8 +5,11 @@
 #ifndef QFPHELPERS
 #define QFPHELPERS
 
+#include "InfoStream.h"
+
 #include <ostream>
 #include <iostream>
+#include <sstream>
 #include <type_traits>
 #include <float.h>
 #include <random>
@@ -22,24 +25,9 @@ namespace QFPHelpers {
 
 const int RAND_SEED = 1;
 const bool NO_SUBNORMALS = true;
-
-//used for directing output to nowhere if wanted
-class InfoStream : public std::ostream{
-  class NullBuffer : public std::streambuf
-  {
-  public:
-    int overflow(int c) { return c; }
-  };
-public:
-  InfoStream() : std::ostream(new NullBuffer()) {}
-  void reinit(std::streambuf* b) { init(b); }
-  void show() { reinit(std::cout.rdbuf()); }
-  void hide() { reinit(new NullBuffer()); }
-};
+extern thread_local InfoStream info_stream;
 
 static void printOnce(std::string, void*);
-
-extern InfoStream info_stream;
 
 // returns a bitlength equivalent unsigned type for floats
 // and a bitlength equivalent floating type for integral types
@@ -250,7 +238,7 @@ struct FPWrap{
   friend std::ostream& operator<<(std::ostream& os, FPWrap<U> const &w);
 };
 
-  extern std::mutex ostreamMutex;
+extern std::mutex ostreamMutex;
 
 template <typename U>
 std::ostream& operator<<(std::ostream& os, const FPWrap<U> &w){


### PR DESCRIPTION
- Move InfoStream to separate files (InfoStream.h and InfoStream.cpp),
  but InfoStream.h is still included by QFPHelpers.h and the class is
  still in the QFPHelpers namespace.
- The way it is now thread-safe is by creating an InfoStream object for
  each thread (info_stream is a thread_local object).
- You are to output to each one, which then buffers the output.
- The output goes to the console when you call the flushout() method,
  which for convenience is called on destruction (so on thread
  distruction it will output).  But you can call flushout() yourself to
  decide when you want to put all of the current output in a contiguous
  block in the console.
- Each thread will therefore have a contiguous block of output, and also
  therefore each task will have a contiguous block of output.