### PR TITLE
Issue 011

### DIFF
--- a/perpVects/MakefileDev
+++ b/perpVects/MakefileDev
@@ -8,6 +8,9 @@ CPPFLAGS ?= -Wuninitialized -g #-fsanitize=thread
 CPPFLAGS += $(FFLAGS)
 CPPFLAGS += -std=c++14
 CPPFLAGS += -Wno-shift-count-overflow
+CPPFLAGS += -Wall
+CPPFLAGS += -Wextra
+CPPFLAGS += -Werror
 CPPFLAGS += -MMD
 CPPFLAGS += -lm
 CPPFLAGS += -lpthread

--- a/perpVects/QFPHelpers.cpp
+++ b/perpVects/QFPHelpers.cpp
@@ -10,9 +10,7 @@
 
 namespace QFPHelpers {
 
-static
-void
-printOnce(std::string s, void* addr){
+void printOnce(std::string s, void* addr){
   return;
   static std::unordered_map<void*, std::string> seen;
   if(seen.count(addr) == 0){

--- a/perpVects/eigenMain.h
+++ b/perpVects/eigenMain.h
@@ -42,6 +42,7 @@
 #include <deque>
 #include <queue>
 #include <list>
+#include <map>
 
 
 // To test that all calls from Eigen code to std::min() and std::max() are
@@ -214,7 +215,7 @@ getFileNoEx(std::string path){
 }
 
 inline void verify_impl(cond_t condition, const char *testname, const char *file,
-                        int line, const char *condition_as_string, bool invert = false)
+                        int line, const char* /*condition_as_string*/, bool invert = false)
 {
   auto fname = getFileNoEx(file);
   bool cond = condition.first != invert;
@@ -245,7 +246,7 @@ inline void verify_impl(cond_t condition, const char *testname, const char *file
 }
 
 inline void verify_impl(bool condition, const char *testname, const char *file,
-                        int line, const char *condition_as_string)
+                        int line, const char* /*condition_as_string*/)
 {
   std::string fname = getFileNoEx(file);
   if(eigenResults.find(fname) == eigenResults.end()){

--- a/perpVects/main.cpp
+++ b/perpVects/main.cpp
@@ -134,7 +134,8 @@ main(int argc, char* argv[]){
     for(auto& t : TestBase::getTests()){
       auto plist = t.second->create();
       for(auto pt : plist){
-        while(DEGP == futures.size()) checkFutures(futures, timeout, scores, false);
+        while(static_cast<uint>(DEGP) == futures.size())
+          checkFutures(futures, timeout, scores, false);
         futures.push_back(std::async(std::launch::async,
                                      [pt,ip]{auto retVal =   (*pt)(ip);
                                        delete pt; return retVal;}));

--- a/perpVects/testBase.h
+++ b/perpVects/testBase.h
@@ -88,7 +88,8 @@ public:
   public:                                                \
     klass(std::string id) : QFPTest::TestBase(id){}      \
     QFPTest::resultType                                  \
-    operator()(const QFPTest::testInput& ti){            \
+    operator()(const QFPTest::testInput& ti) {           \
+      Q_UNUSED(ti);                                      \
       if(sizeof(T) != 4) return {};                      \
       auto fileS = std::string(#file);                   \
       g_test_stack_mutex.lock();                         \

--- a/perpVects/tests/DistributivityOfMultiplication.cpp
+++ b/perpVects/tests/DistributivityOfMultiplication.cpp
@@ -24,8 +24,6 @@ public:
       T a = std::get<0>(input);
       T b = std::get<1>(input);
       T c = std::get<2>(input);
-      T dist = (a * c) + (b * c);
-      T undist = (a + b) * c;
       valuesDistributed.push_back((a * c) + (b * c));
       valuesUndistributed.push_back((a + b) * c);
       QFPHelpers::info_stream << std::setw(8);

--- a/perpVects/tests/DoOrthoPerturbTest.cpp
+++ b/perpVects/tests/DoOrthoPerturbTest.cpp
@@ -28,16 +28,17 @@ public:
 
     QFPHelpers::info_stream << "starting dot product orthogonality test with a, b = "
                             << std::endl;
-    for(int x = 0; x < dim; ++x) QFPHelpers::info_stream << x << '\t';
+    for(decltype(dim) x = 0; x < dim; ++x)
+      QFPHelpers::info_stream << x << '\t';
     QFPHelpers::info_stream << std::endl;
     QFPHelpers::info_stream << a << std::endl;
     QFPHelpers::info_stream << b << std::endl;
     T backup;
 
-    for(int r = 0; r < dim; ++r){
+    for(decltype(dim) r = 0; r < dim; ++r){
     T &p = a[r];
       backup = p;
-      for(int i = 0; i < iters; ++i){
+      for(decltype(iters) i = 0; i < iters; ++i){
         //cout << "r:" << r << ":i:" << i << std::std::endl;
         p = QFPHelpers::FPHelpers::perturbFP(backup, i * ulp_inc);
         // Added this for force watchpoint hits every cycle (well, two).  We

--- a/perpVects/tests/RotateFullCircle.cpp
+++ b/perpVects/tests/RotateFullCircle.cpp
@@ -17,7 +17,7 @@ public:
     auto orig = A;
     T theta = 2 * M_PI / n;
     QFPHelpers::info_stream << "Rotate full circle in " << n << " increments, A is: " << A << std::endl;
-    for(int r = 0; r < n; ++r){
+    for(decltype(n) r = 0; r < n; ++r){
       A.rotateAboutZ_3d(theta);
       QFPHelpers::info_stream << r << " rotations, vect = " << A << std::endl;
     }


### PR DESCRIPTION
* Fixed all warnings (from -Wall and -Wextra)
* Removed functions projectType() and replaced usage with reinterpret functions
* Add zeroing out the top bits of long double -> unsigned __int128 to the reinterpret functions
* Place reinterpret functions at the top of the namespace so they can be used.  This was chosen instead of forward declaring the template functions, because forward declaring templates is hard :)