### PR TITLE
replace master with main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/LICENSE
+++ b/LICENSE
@@ -19,7 +19,7 @@ License
   This file is part of FLiT. For details, see
     https://pruners.github.io/flit
   Please also read
-    https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+    https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 
   Redistribution and use in source and binary forms, with or
   without modification, are permitted provided that the following

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 | branch  | status  |
 |---------|---------|
-| master  | [![Build Status](https://travis-ci.org/PRUNERS/FLiT.svg?branch=master)](https://travis-ci.org/PRUNERS/FLiT) |
+| main    | [![Build Status](https://travis-ci.org/PRUNERS/FLiT.svg?branch=main)](https://travis-ci.org/PRUNERS/FLiT) |
 | devel   | [![Build Status](https://travis-ci.org/PRUNERS/FLiT.svg?branch=devel)](https://travis-ci.org/PRUNERS/FLiT) |
 
 ![PyPI - License](https://img.shields.io/pypi/l/Django.svg)

--- a/benchmarks/polybench/main.cpp
+++ b/benchmarks/polybench/main.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/adi.cpp
+++ b/benchmarks/polybench/tests/adi.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/atax.cpp
+++ b/benchmarks/polybench/tests/atax.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/bicg.cpp
+++ b/benchmarks/polybench/tests/bicg.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/cholesky.cpp
+++ b/benchmarks/polybench/tests/cholesky.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/correlation.cpp
+++ b/benchmarks/polybench/tests/correlation.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/covariance.cpp
+++ b/benchmarks/polybench/tests/covariance.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/deriche.cpp
+++ b/benchmarks/polybench/tests/deriche.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/doitgen.cpp
+++ b/benchmarks/polybench/tests/doitgen.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/durbin.cpp
+++ b/benchmarks/polybench/tests/durbin.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/fdtd_2d.cpp
+++ b/benchmarks/polybench/tests/fdtd_2d.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/floyd_warshall.cpp
+++ b/benchmarks/polybench/tests/floyd_warshall.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/gemm.cpp
+++ b/benchmarks/polybench/tests/gemm.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/gemver.cpp
+++ b/benchmarks/polybench/tests/gemver.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/gesummv.cpp
+++ b/benchmarks/polybench/tests/gesummv.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/gramschmidt.cpp
+++ b/benchmarks/polybench/tests/gramschmidt.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/heat_3d.cpp
+++ b/benchmarks/polybench/tests/heat_3d.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/jacobi_1d.cpp
+++ b/benchmarks/polybench/tests/jacobi_1d.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/jacobi_2d.cpp
+++ b/benchmarks/polybench/tests/jacobi_2d.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/lu.cpp
+++ b/benchmarks/polybench/tests/lu.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/ludcmp.cpp
+++ b/benchmarks/polybench/tests/ludcmp.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/mvt.cpp
+++ b/benchmarks/polybench/tests/mvt.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/nussinov.cpp
+++ b/benchmarks/polybench/tests/nussinov.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/polybench_utils.h
+++ b/benchmarks/polybench/tests/polybench_utils.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/seidel_2d.cpp
+++ b/benchmarks/polybench/tests/seidel_2d.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/symm.cpp
+++ b/benchmarks/polybench/tests/symm.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/syr2k.cpp
+++ b/benchmarks/polybench/tests/syr2k.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/syrk.cpp
+++ b/benchmarks/polybench/tests/syrk.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/test2mm.cpp
+++ b/benchmarks/polybench/tests/test2mm.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/test3mm.cpp
+++ b/benchmarks/polybench/tests/test3mm.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/trisolv.cpp
+++ b/benchmarks/polybench/tests/trisolv.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/polybench/tests/trmm.cpp
+++ b/benchmarks/polybench/tests/trmm.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/random/main.cpp
+++ b/benchmarks/random/main.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/random/tests/Rand.cpp
+++ b/benchmarks/random/tests/Rand.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/benchmarks/random/tests/Random.cpp
+++ b/benchmarks/random/tests/Random.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/data/Makefile.in
+++ b/data/Makefile.in
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/data/Makefile_bisect_binary.in
+++ b/data/Makefile_bisect_binary.in
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/data/custom.mk
+++ b/data/custom.mk
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/data/db/tables-sqlite.sql
+++ b/data/db/tables-sqlite.sql
@@ -19,7 +19,7 @@
 -- This file is part of FLiT. For details, see
 --   https://pruners.github.io/flit
 -- Please also read
---   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+--   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 --
 -- Redistribution and use in source and binary forms, with or
 -- without modification, are permitted provided that the following

--- a/data/main.cpp
+++ b/data/main.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/data/tests/Empty.cpp
+++ b/data/tests/Empty.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/gensrc/environment.py
+++ b/gensrc/environment.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/gensrc/expression.py
+++ b/gensrc/expression.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/gensrc/gensrc.py
+++ b/gensrc/gensrc.py
@@ -21,7 +21,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/gensrc/testcase.py
+++ b/gensrc/testcase.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/inputGen/groundtruth.cpp
+++ b/inputGen/groundtruth.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/inputGen/groundtruth.h
+++ b/inputGen/groundtruth.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/inputGen/helper.cpp
+++ b/inputGen/helper.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/inputGen/helper.h
+++ b/inputGen/helper.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/inputGen/main.cpp
+++ b/inputGen/main.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/inputGen/makefile
+++ b/inputGen/makefile
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/inputGen/testbed.cpp
+++ b/inputGen/testbed.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/inputGen/testbed.h
+++ b/inputGen/testbed.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/DistributivityOfMultiplication.cpp
+++ b/litmus-tests/tests/DistributivityOfMultiplication.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/DoHariGSBasic.cpp
+++ b/litmus-tests/tests/DoHariGSBasic.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/DoHariGSImproved.cpp
+++ b/litmus-tests/tests/DoHariGSImproved.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/DoMatrixMultSanity.cpp
+++ b/litmus-tests/tests/DoMatrixMultSanity.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/DoOrthoPerturbTest.cpp
+++ b/litmus-tests/tests/DoOrthoPerturbTest.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/DoSimpleRotate90.cpp
+++ b/litmus-tests/tests/DoSimpleRotate90.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/DoSkewSymCPRotationTest.cpp
+++ b/litmus-tests/tests/DoSkewSymCPRotationTest.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/FMACancel.cpp
+++ b/litmus-tests/tests/FMACancel.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/InliningProblem.cpp
+++ b/litmus-tests/tests/InliningProblem.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/Kahan.h
+++ b/litmus-tests/tests/Kahan.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/KahanSum.cpp
+++ b/litmus-tests/tests/KahanSum.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/Matrix.h
+++ b/litmus-tests/tests/Matrix.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/Paranoia.cpp
+++ b/litmus-tests/tests/Paranoia.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/RandHelper.cpp
+++ b/litmus-tests/tests/RandHelper.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/RandHelper.h
+++ b/litmus-tests/tests/RandHelper.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/ReciprocalMath.cpp
+++ b/litmus-tests/tests/ReciprocalMath.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/RotateAndUnrotate.cpp
+++ b/litmus-tests/tests/RotateAndUnrotate.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/RotateFullCircle.cpp
+++ b/litmus-tests/tests/RotateFullCircle.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/Shewchuk.h
+++ b/litmus-tests/tests/Shewchuk.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/ShewchukSum.cpp
+++ b/litmus-tests/tests/ShewchukSum.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/SimpleCHull.cpp
+++ b/litmus-tests/tests/SimpleCHull.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/SinInt.cpp
+++ b/litmus-tests/tests/SinInt.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/TrianglePHeron.cpp
+++ b/litmus-tests/tests/TrianglePHeron.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/TrianglePSylv.cpp
+++ b/litmus-tests/tests/TrianglePSylv.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/Vector.h
+++ b/litmus-tests/tests/Vector.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/langois.cpp
+++ b/litmus-tests/tests/langois.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/simple_convex_hull.cpp
+++ b/litmus-tests/tests/simple_convex_hull.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/simple_convex_hull.h
+++ b/litmus-tests/tests/simple_convex_hull.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/litmus-tests/tests/tinys.cpp
+++ b/litmus-tests/tests/tinys.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/plotting/compare_matrix.py
+++ b/plotting/compare_matrix.py
@@ -21,7 +21,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/plotting/pivot_table.py
+++ b/plotting/pivot_table.py
@@ -21,7 +21,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/plotting/plot_speedup_histogram.py
+++ b/plotting/plot_speedup_histogram.py
@@ -21,7 +21,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/plotting/plot_timing.py
+++ b/plotting/plot_timing.py
@@ -21,7 +21,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/plotting/stats_generator.py
+++ b/plotting/stats_generator.py
@@ -21,7 +21,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/config/flit-default.toml.in
+++ b/scripts/flitcli/config/flit-default.toml.in
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/experimental/flit_ninja.py
+++ b/scripts/flitcli/experimental/flit_ninja.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/flit.py
+++ b/scripts/flitcli/flit.py
@@ -21,7 +21,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/flit_bisect.py
+++ b/scripts/flitcli/flit_bisect.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flitK
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/flit_experimental.py
+++ b/scripts/flitcli/flit_experimental.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/flit_import.py
+++ b/scripts/flitcli/flit_import.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/flit_init.py
+++ b/scripts/flitcli/flit_init.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/flit_make.py
+++ b/scripts/flitcli/flit_make.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/flit_update.py
+++ b/scripts/flitcli/flit_update.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/flitconfig.py
+++ b/scripts/flitcli/flitconfig.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/flitelf.py
+++ b/scripts/flitcli/flitelf.py
@@ -22,7 +22,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/flitutil.py
+++ b/scripts/flitcli/flitutil.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/unfinished/flit_analyze.py
+++ b/scripts/flitcli/unfinished/flit_analyze.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/unfinished/flit_check.py
+++ b/scripts/flitcli/unfinished/flit_check.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/flitcli/unfinished/flit_run.py
+++ b/scripts/flitcli/unfinished/flit_run.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/scripts/watch-progress.sh
+++ b/scripts/watch-progress.sh
@@ -20,7 +20,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/src/flit.h
+++ b/src/flit.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/ALL-FLIT.cpp
+++ b/src/flit/ALL-FLIT.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/FlitCsv.cpp
+++ b/src/flit/FlitCsv.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/FlitCsv.h
+++ b/src/flit/FlitCsv.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/InfoStream.cpp
+++ b/src/flit/InfoStream.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/InfoStream.h
+++ b/src/flit/InfoStream.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/TestBase.cpp
+++ b/src/flit/TestBase.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/TestBase.h
+++ b/src/flit/TestBase.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/Variant.cpp
+++ b/src/flit/Variant.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/Variant.h
+++ b/src/flit/Variant.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/flit.cpp
+++ b/src/flit/flit.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/flit.h
+++ b/src/flit/flit.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/flitHelpers.cpp
+++ b/src/flit/flitHelpers.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/flitHelpers.h
+++ b/src/flit/flitHelpers.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/fsutil.cpp
+++ b/src/flit/fsutil.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/fsutil.h
+++ b/src/flit/fsutil.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/subprocess.cpp
+++ b/src/flit/subprocess.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/subprocess.h
+++ b/src/flit/subprocess.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/timeFunction.cpp
+++ b/src/flit/timeFunction.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/src/flit/timeFunction.h
+++ b/src/flit/timeFunction.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/A.cpp
+++ b/tests/flit_cli/flit_bisect/data/tests/A.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/A.h
+++ b/tests/flit_cli/flit_bisect/data/tests/A.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/BisectTest.cpp
+++ b/tests/flit_cli/flit_bisect/data/tests/BisectTest.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/file1.cpp
+++ b/tests/flit_cli/flit_bisect/data/tests/file1.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/file1.h
+++ b/tests/flit_cli/flit_bisect/data/tests/file1.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/file2.cpp
+++ b/tests/flit_cli/flit_bisect/data/tests/file2.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/file2.h
+++ b/tests/flit_cli/flit_bisect/data/tests/file2.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/file3.cpp
+++ b/tests/flit_cli/flit_bisect/data/tests/file3.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/file3.h
+++ b/tests/flit_cli/flit_bisect/data/tests/file3.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/file4.cxx
+++ b/tests/flit_cli/flit_bisect/data/tests/file4.cxx
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/data/tests/file4.h
+++ b/tests/flit_cli/flit_bisect/data/tests/file4.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/tst_bisect.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/tst_bisect_autosqlite_clang.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect_autosqlite_clang.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/tst_bisect_biggest.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect_biggest.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/tst_bisect_compilerspecificflags.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect_compilerspecificflags.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_bisect/tst_bisect_linkstep.py
+++ b/tests/flit_cli/flit_bisect/tst_bisect_linkstep.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_import/tst_dbfile.py
+++ b/tests/flit_cli/flit_import/tst_dbfile.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_init/tst_litmustests.py
+++ b/tests/flit_cli/flit_init/tst_litmustests.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_update/tst_badconfig.py
+++ b/tests/flit_cli/flit_update/tst_badconfig.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_update/tst_common_funcs.py
+++ b/tests/flit_cli/flit_update/tst_common_funcs.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_update/tst_compilerspecificflags.py
+++ b/tests/flit_cli/flit_update/tst_compilerspecificflags.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_update/tst_nocompilers.py
+++ b/tests/flit_cli/flit_update/tst_nocompilers.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_update/tst_nooptl.py
+++ b/tests/flit_cli/flit_update/tst_nooptl.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_update/tst_noswitches.py
+++ b/tests/flit_cli/flit_update/tst_noswitches.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_update/tst_onlyprovidedcompilers.py
+++ b/tests/flit_cli/flit_update/tst_onlyprovidedcompilers.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_update/tst_onlyprovidedoptlswitches.py
+++ b/tests/flit_cli/flit_update/tst_onlyprovidedoptlswitches.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_cli/flit_version/tst_version.py
+++ b/tests/flit_cli/flit_version/tst_version.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_install/tst_install_runthrough.py
+++ b/tests/flit_install/tst_install_runthrough.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_install/tst_uninstall_runthrough.py
+++ b/tests/flit_install/tst_uninstall_runthrough.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_makefile/tst_build_with_compiler_specific_flags.py
+++ b/tests/flit_makefile/tst_build_with_compiler_specific_flags.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_makefile/tst_clang34.py
+++ b/tests/flit_makefile/tst_clang34.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_makefile/tst_empty_project.py
+++ b/tests/flit_makefile/tst_empty_project.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_makefile/tst_gcc4.py
+++ b/tests/flit_makefile/tst_gcc4.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_makefile/tst_incremental_build.py
+++ b/tests/flit_makefile/tst_incremental_build.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_mpi/data/MpiFloat.cpp
+++ b/tests/flit_mpi/data/MpiFloat.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_mpi/data/MpiHello.cpp
+++ b/tests/flit_mpi/data/MpiHello.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_mpi/tst_run_mpi.py
+++ b/tests/flit_mpi/tst_run_mpi.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_mpi/tst_run_mpi_templated.py
+++ b/tests/flit_mpi/tst_run_mpi_templated.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/flit_src/tst_FlitCsv.cpp
+++ b/tests/flit_src/tst_FlitCsv.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_src/tst_TestBase.cpp
+++ b/tests/flit_src/tst_TestBase.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_src/tst_Variant.cpp
+++ b/tests/flit_src/tst_Variant.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_src/tst_flitHelpers_h.cpp
+++ b/tests/flit_src/tst_flitHelpers_h.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_src/tst_flit_cpp.cpp
+++ b/tests/flit_src/tst_flit_cpp.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_src/tst_fsutil.cpp
+++ b/tests/flit_src/tst_fsutil.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/flit_src/tst_subprocess.cpp
+++ b/tests/flit_src/tst_subprocess.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/harness/tst_test_harness.cpp
+++ b/tests/harness/tst_test_harness.cpp
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/shared/fake_clang34.py
+++ b/tests/shared/fake_clang34.py
@@ -20,7 +20,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/shared/fake_gcc4.py
+++ b/tests/shared/fake_gcc4.py
@@ -20,7 +20,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/shared/fake_gcc9.py
+++ b/tests/shared/fake_gcc9.py
@@ -20,7 +20,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/shared/fake_intel19.py
+++ b/tests/shared/fake_intel19.py
@@ -20,7 +20,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following

--- a/tests/test_harness.h
+++ b/tests/test_harness.h
@@ -19,7 +19,7 @@
  * This file is part of FLiT. For details, see
  *   https://pruners.github.io/flit
  * Please also read
- *   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+ *   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
  *
  * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -19,7 +19,7 @@
 # This file is part of FLiT. For details, see
 #   https://pruners.github.io/flit
 # Please also read
-#   https://github.com/PRUNERS/FLiT/blob/master/LICENSE
+#   https://github.com/PRUNERS/FLiT/blob/main/LICENSE
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following


### PR DESCRIPTION
Related to issue #329 

### Description:

Fixes all references to FLiT's old `master` branch and replaces them with the `main` branch.  This pull request is specifically for the `main` branch.

Similar pull requests will be made for all other branches.  Once all other branches besides `devel` are finished, I will create another pull request for the `devel` branch which will conclude this issue.